### PR TITLE
ProtoSQL: don't assume class of repeated field

### DIFF
--- a/src/main/scala/com/trueaccord/scalapb/spark/ProtoSQL.scala
+++ b/src/main/scala/com/trueaccord/scalapb/spark/ProtoSQL.scala
@@ -41,7 +41,7 @@ object ProtoSQL {
           val obj = msg.getField(fd)
           if (obj != null) {
             if (fd.isRepeated) {
-              obj.asInstanceOf[Vector[Any]].map(toRowData(fd, _))
+              obj.asInstanceOf[Traversable[Any]].map(toRowData(fd, _))
             } else {
               toRowData(fd, obj)
             }


### PR DESCRIPTION
Depending on whether the proto passed through `fromJavaProto`, on disk
from network, etc, it can be a lot of different things besides just
a Vector. Thus, only assume that it's something with a `map` method,
which is all we need anyway.

Fixes stuff like:

```
java.lang.ClassCastException: scala.collection.mutable.ArrayBuffer cannot be cast to scala.collection.immutable.Vector
        at com.trueaccord.scalapb.spark.ProtoSQL$$anonfun$messageToRow$1.apply(ProtoSQL.scala:44)
        at com.trueaccord.scalapb.spark.ProtoSQL$$anonfun$messageToRow$1.apply(ProtoSQL.scala:40)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.TraversableLike$$anonfun$map$1.apply(TraversableLike.scala:234)
        at scala.collection.Iterator$class.foreach(Iterator.scala:893)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
        at scala.collection.IterableLike$class.foreach(IterableLike.scala:72)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:54)
        at scala.collection.TraversableLike$class.map(TraversableLike.scala:234)
        at scala.collection.AbstractTraversable.map(Traversable.scala:104)
        at com.trueaccord.scalapb.spark.ProtoSQL$.messageToRow(ProtoSQL.scala:39)
        at com.trueaccord.scalapb.spark.ProtoSQL$$anonfun$protoToDataFrame$1.apply(ProtoSQL.scala:15)
        at com.trueaccord.scalapb.spark.ProtoSQL$$anonfun$protoToDataFrame$1.apply(ProtoSQL.scala:15)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
        at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.agg_doAggregateWithoutKey$(Unknown Source)
        at org.apache.spark.sql.catalyst.expressions.GeneratedClass$GeneratedIterator.processNext(Unknown Source)
        at org.apache.spark.sql.execution.BufferedRowIterator.hasNext(BufferedRowIterator.java:43)
        at org.apache.spark.sql.execution.WholeStageCodegenExec$$anonfun$8$$anon$1.hasNext(WholeStageCodegenExec.scala:370)
        at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:408)
        at org.apache.spark.shuffle.sort.BypassMergeSortShuffleWriter.write(BypassMergeSortShuffleWriter.java:125)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:79)
        at org.apache.spark.scheduler.ShuffleMapTask.runTask(ShuffleMapTask.scala:47)
        at org.apache.spark.scheduler.Task.run(Task.scala:85)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:274)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)```